### PR TITLE
docs: fix simple typo, suprocess -> subprocess

### DIFF
--- a/pymacds-dist/pymacds/__init__.py
+++ b/pymacds-dist/pymacds/__init__.py
@@ -42,7 +42,7 @@ class DSException(Exception):
 
 def RunProcess(cmd, stdinput=None, env=None, cwd=None, sudo=False,
                sudo_password=None):
-  """Executes cmd using suprocess.
+  """Executes cmd using subprocess.
 
   Args:
     cmd: An array of strings as the command to run


### PR DESCRIPTION
There is a small typo in pymacds-dist/pymacds/__init__.py.

Should read `subprocess` rather than `suprocess`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md